### PR TITLE
コントローラ下地

### DIFF
--- a/TypeScript/appTodoForCLI/app.js
+++ b/TypeScript/appTodoForCLI/app.js
@@ -1,0 +1,4 @@
+import { TodoController } from './controller.js';
+const app = new TodoController();
+app.run();
+//# sourceMappingURL=app.js.map

--- a/TypeScript/appTodoForCLI/app.ts
+++ b/TypeScript/appTodoForCLI/app.ts
@@ -1,0 +1,4 @@
+import { TodoController } from './controller.js';
+
+const app = new TodoController();
+app.run();

--- a/TypeScript/appTodoForCLI/controller.js
+++ b/TypeScript/appTodoForCLI/controller.js
@@ -1,0 +1,15 @@
+/**
+ * ユーザの入力を受け付け、各種モジュールを呼び出すことを責務に持つ
+ */
+export class TodoController {
+    constructor() {
+        /**
+         * 開始処理
+         */
+        this.run = () => {
+            console.log(TodoController.START_MESSAGE);
+        };
+    }
+}
+TodoController.START_MESSAGE = 'Start';
+//# sourceMappingURL=controller.js.map

--- a/TypeScript/appTodoForCLI/controller.ts
+++ b/TypeScript/appTodoForCLI/controller.ts
@@ -1,0 +1,17 @@
+/**
+ * ユーザの入力を受け付け、各種モジュールを呼び出すことを責務に持つ
+ */
+export class TodoController {
+
+    static START_MESSAGE = 'Start';
+
+    constructor() {}
+
+    /**
+     * 開始処理
+     */
+    public run = (): void => {
+
+        console.log(TodoController.START_MESSAGE);
+    }
+}

--- a/TypeScript/appTodoForCLI/tests/controller.test.js
+++ b/TypeScript/appTodoForCLI/tests/controller.test.js
@@ -1,0 +1,15 @@
+import { TodoController } from '../controller';
+import { jest } from '@jest/globals';
+test('開始メッセージが出力されること', () => {
+    // GIVEN
+    const consoleMock = jest.fn();
+    console.log = consoleMock;
+    const expected = TodoController.START_MESSAGE;
+    // WHEN
+    const sut = new TodoController();
+    sut.run();
+    // THEN
+    const actual = consoleMock.mock.calls[0][0];
+    expect(actual).toBe(expected);
+});
+//# sourceMappingURL=controller.test.js.map

--- a/TypeScript/appTodoForCLI/tests/controller.test.ts
+++ b/TypeScript/appTodoForCLI/tests/controller.test.ts
@@ -1,0 +1,18 @@
+import { TodoController } from '../controller';
+import {jest} from '@jest/globals';
+
+test('開始メッセージが出力されること', () => {
+
+    // GIVEN
+    const consoleMock = jest.fn();
+    console.log = consoleMock;
+    const expected = TodoController.START_MESSAGE;
+
+    // WHEN
+    const sut = new TodoController();
+    sut.run();
+
+    // THEN
+    const actual = consoleMock.mock.calls[0][0];
+    expect(actual).toBe(expected);
+});


### PR DESCRIPTION
## Controllerの下地

簡単な機能から積み上げていった方が良さそうなので、まずはControllerからつくる。
run()メソッドを呼び出したら標準出力へ文字列が出力されるところまでを実装→テストしたい。

コンソール操作はspyon()が必要になりそう。
この機会にCLIアプリケーションのテスト手法を確立したい。

→コンソール操作は`jest.fn()`でモック化することで解決。