### PR TITLE
タスク作成処理

### DIFF
--- a/TypeScript/appTodoForCLI/task.ts
+++ b/TypeScript/appTodoForCLI/task.ts
@@ -1,0 +1,44 @@
+import { writeFile } from 'fs/promises';
+
+/**
+ * タスクのCRUDを責務に持つ
+ */
+export class Task {
+
+    private fileHandler: TaskFile;
+
+    constructor(filePath: string) {
+        this.fileHandler = new TaskFile(filePath);
+    }
+
+    /**
+     * タスクを追加
+     *
+     * @param content 追加タスク
+     */
+    public add = (content: string) => {
+
+        this.fileHandler.writeLine(content);
+    }
+}
+
+/**
+ * タスクのファイル操作を責務に持つ
+ */
+export class TaskFile {
+
+    private readonly filePath: string;
+
+    constructor(filePath: string) {
+        this.filePath = filePath;
+    }
+
+    /**
+     * 対象ファイルへタスクを書き込む
+     *
+     * @param content タスク
+     */
+    public writeLine = async (content: string) => {
+        await writeFile(this.filePath, `${content}\n`, {flag: 'a+'});
+    }
+}

--- a/TypeScript/appTodoForCLI/tests/task.test.ts
+++ b/TypeScript/appTodoForCLI/tests/task.test.ts
@@ -1,0 +1,65 @@
+import { readFile, readdir, rm } from 'fs/promises';
+import { Task, TaskFile } from '../task';
+import { clearTmpDir, TMP_DIR_PATH } from './util';
+
+describe('TaskFile', () => {
+
+    // 毎回一時ディレクトリをクリア
+    beforeEach(async () => {
+        await clearTmpDir();
+    });
+
+    test('ファイルが無ければ新規作成されること', async () => {
+
+        // GIVEN
+        const tmpFilePath = `${TMP_DIR_PATH}/task.txt`;
+
+        // WHEN
+        const sut = new TaskFile(tmpFilePath);
+        await sut.writeLine('content');
+
+        // THEN
+        const actual = await readFile(tmpFilePath, { encoding: 'utf-8' });
+        expect(actual).not.toBeFalsy();
+    });
+
+    // ファイルへ追記できるか
+    test('ファイルへ追記できること', async () => {
+
+        // GIVEN
+        const tmpFilePath = `${TMP_DIR_PATH}/task.txt`;
+        const expected = 'hello\nworld\n'
+
+        // WHEN
+        const sut = new TaskFile(tmpFilePath);
+        await sut.writeLine('hello');
+        await sut.writeLine('world');
+
+        // THEN
+        const actual = await readFile(tmpFilePath, { encoding: 'utf-8' });
+        expect(actual).toBe(expected);
+    });
+});
+
+
+describe('Task', () => {
+
+    // 毎回一時ディレクトリをクリア
+    beforeEach(async () => {
+        await clearTmpDir();
+    });
+
+    test('addメソッドでタスクを追加できること', async () => {
+        // GIVEN
+        const tmpFilePath = `${TMP_DIR_PATH}/task.txt`;
+        const expected = 'task\n';
+
+        // WHEN
+        const sut = new Task(tmpFilePath);
+        sut.add('task');
+
+        // THEN
+        const actual = await readFile(tmpFilePath, { encoding: 'utf-8' });
+        expect(actual).toBe(expected);
+    })
+});

--- a/TypeScript/appTodoForCLI/tests/util.ts
+++ b/TypeScript/appTodoForCLI/tests/util.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {readdir, rm} from 'fs/promises';
+
+/**
+ * カレントディレクトリ名を取得
+ *
+ */
+export const get__dirname = (): string => {
+
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    return __dirname;
+};
+
+export const TMP_DIR_PATH = `${get__dirname()}/tmpdir`;
+
+/**
+ * テスト用の一時ディレクトリを初期化
+ */
+export const clearTmpDir = async () => {
+
+    const files = await readdir(TMP_DIR_PATH);
+
+    for (const file of files) {
+        const rmPath = `${TMP_DIR_PATH}/${file}`;
+        await rm(rmPath);
+    }
+}


### PR DESCRIPTION
### create処理

タスクを受け取り、ファイルがなければ作成・あれば追記する処理を作成。
TaskFileクラスでファイル操作を、Taskクラスで入力のバリデーションを実施。

TaskFile→Taskの順に組み上げていくか。